### PR TITLE
Updated the current mod information

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,6 @@
   "custom": {
     "modmenu": {
       "links": {
-        "modmenu.github_releases": "https://github.com/ThatCreeper/AngledParticles/releases",
         "modmenu.modrinth": "https://modrinth.com/mod/angled-particles"
       }
     }


### PR DESCRIPTION
Now Modmenu will display the link to the Modrinth and Github pages, as well as the current MIT license and author.